### PR TITLE
Give each editor their own PythonProvider

### DIFF
--- a/src/components/CodeEditor/CodeEditor2.tsx
+++ b/src/components/CodeEditor/CodeEditor2.tsx
@@ -3,7 +3,7 @@ import { produce } from 'immer'
 import { TabsProvider, useTabs } from './EditorContext'
 import clsx from 'clsx'
 
-import { usePython } from 'react-py'
+import { PythonProvider, usePython } from 'react-py'
 import type { Packages } from 'react-py/dist/types/Packages'
 import type { Tab } from './EditorContext'
 
@@ -70,9 +70,11 @@ interface CodeEditorProps {
 
 export default function CodeEditor2(props: CodeEditorProps) {
   return (
-    <TabsProvider tabs={props.tabs}>
-      <CodeEditor {...props} />
-    </TabsProvider>
+    <PythonProvider terminateOnCompletion={true} lazy={true}>
+      <TabsProvider tabs={props.tabs}>
+        <CodeEditor {...props} />
+      </TabsProvider>
+    </PythonProvider>
   )
 }
 

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -31,7 +31,6 @@ export default function App({ Component, pageProps, router }) {
 
   return (
     <>
-    <PythonProvider lazy={true} terminateOnCompletion={true}>
       <div className="fixed inset-0 flex justify-center sm:px-8">
         <div className="flex w-full max-w-7xl lg:px-8">
           <div className="w-full" />
@@ -44,7 +43,6 @@ export default function App({ Component, pageProps, router }) {
           <Analytics />
         </main>
       </div>
-    </PythonProvider>
     </>
   )
 }


### PR DESCRIPTION
This is the first step in a performance improvement that will cause only the first call to Python to be slow for each editor. Currently every call to Python is experiencing additional slowness due to `terminateOnCompletion={true}`.

This should enable us to separately manage the `terminateOnCompletion={true}` prop of each instance in `CodeEditor2.tsx`. Basically, before we run the code on an Editor we should set this prop to false, while also setting it to true for any other Editor instance. This is apparently necessary to deal with performance problems that arise with having many editors on the screen, each of which is maybe loading several libraries or the entirety of Python.

The goal is to have only 1-2 workers at any given time, but always having fast executions past the first execute per editor, by managing their deletion using the `terminateOnCompletion` prop.